### PR TITLE
Add local client to be used with dria-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const dria = new Dria({ apiKey });
 
 contractId = await dria.create(
   "My New Contract,
-  "jinaai/jina-embeddings-v2-base-en",
+  "jina-embeddings-v2-base-en",
   "Science",
 );
 dria.contractId = contractId;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint '**/*.ts' && echo 'All good.'",
     "test": "bun test --timeout 15000",
     "t": "bun run test",
+    "test:local": "LOCAL_TEST=true bun test local --timeout 15000",
     "proto:code": "npx pbjs ./proto/insert.proto -w commonjs -t static-module -o ./proto/insert.js",
     "proto:type": "npx pbts ./proto/insert.js -o ./proto/insert.d.ts",
     "proto": "bun proto:code && bun proto:type"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dria",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "author": "FirstBatch Team <dev@firstbatch.xyz>",
   "contributors": [

--- a/src/clients/common.ts
+++ b/src/clients/common.ts
@@ -1,0 +1,39 @@
+import { AxiosInstance } from "axios";
+
+/**
+ * A utility class that exposes `post` and `get` requests
+ * for other clients to use. The constructor takes in an Axios instance.
+ */
+export class DriaCommon {
+  constructor(protected readonly client: AxiosInstance) {}
+
+  /**
+   * A POST request wrapper.
+   * @param url request URL
+   * @param body request body
+   * @template T type of response body
+   * @returns parsed response body
+   */
+  protected async post<T = unknown>(url: string, body: unknown) {
+    const res = await this.client.post<{ success: boolean; data: T; code: number }>(url, body);
+    if (res.status !== 200) {
+      throw `Dria API (POST) failed with ${res.statusText} (${res.status}).\n${res.data}`;
+    }
+    return res.data.data;
+  }
+
+  /**
+   * A GET request wrapper.
+   * @param url request URL
+   * @param params query parameters
+   * @template T type of response body
+   * @returns parsed response body
+   */
+  protected async get<T = unknown>(url: string, params: Record<string, unknown> = {}) {
+    const res = await this.client.get<{ success: boolean; data: T; code: number }>(url, { params });
+    if (res.status !== 200) {
+      throw `Dria API (GET) failed with ${res.statusText} (${res.status}).\n${res.data}`;
+    }
+    return res.data.data;
+  }
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,0 +1,2 @@
+export * from "./dria";
+export * from "./local";

--- a/src/clients/local.ts
+++ b/src/clients/local.ts
@@ -1,0 +1,106 @@
+import Axios from "axios";
+import { QueryOptions, BatchVectors, MetadataType } from "../schemas";
+import { DriaCommon } from "./common";
+
+/**
+ * ## Dria Local Client
+ *
+ * Dria local client is a convenience tool that allows one to use the served knowledge via [Dria Docker](https://github.com/firstbatchxyz/dria-docker).
+ * The URL defaults to `http://localhost:8080`, but you can override it.
+ *
+ * Unlike the other Dria client, Dria local does not require an API key or a contract ID, since the locally served knowledge serves a single contract.
+ * Furthermore, text-based input is not allowed as that requires an embedding model to be running on the side.
+ *
+ * @template T default type of metadata; a metadata in Dria is a single-level mapping, with string keys and values of type `string`, `number`
+ *
+ * @example
+ * // connects to http://localhost:8080
+ * const dria = new DriaLocal();
+ *
+ * @example
+ * const dria = new DriaLocal("your-url");
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class DriaLocal<T extends MetadataType = any> extends DriaCommon {
+  public url: string;
+  constructor(url: string = "http://localhost:8080") {
+    super(
+      Axios.create({
+        baseURL: url,
+        headers: {
+          "Content-Type": "application/json",
+          Connection: "keep-alive",
+          Accept: "*/*",
+        },
+        // lets us handle the errors
+        validateStatus: () => true,
+      }),
+    );
+    this.url = url;
+  }
+
+  /** A simple health-check. */
+  async health() {
+    try {
+      await this.get("/health");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** A vector-based query.
+   * @param vector query vector.
+   * @param options query options:
+   * - `topK`: number of results to return.
+   * @template M type of the metadata, defaults to type provided to the client.
+   * @returns an array of `topK` results with id, metadata and the relevancy score.
+   * @example
+   * const res = await dria.query<{about: string}>([0.1, 0.92, ..., 0.16]);
+   * console.log(res[0].metadata.about);
+   */
+  async query<M extends MetadataType = T>(vector: number[], options: QueryOptions = {}) {
+    options = QueryOptions.parse(options);
+    const data = await this.post<{ id: number; metadata: M; score: number }[]>("/query", {
+      vector,
+      top_n: options.topK,
+    });
+    return data;
+  }
+
+  /** Fetch vectors with the given IDs.
+   * @param ids an array of ids.
+   * @template M type of the metadata, defaults to type provided to the client.
+   * @returns an array of metadatas belonging to the given vector IDs.
+   * @example
+   * const res = await dria.fetch([0])
+   * console.log(res[0])
+   */
+  async fetch<M extends MetadataType = T>(ids: number[]) {
+    if (ids.length === 0) throw "No IDs provided.";
+    const data = await this.post<M[]>("/fetch", {
+      id: ids,
+    });
+    return data;
+  }
+
+  /**
+   * Insert a batch of vectors to your existing knowledge.
+   * @param items batch of vectors with optional metadatas
+   * @returns a string indicating success
+   * @example
+   * const batch = [
+   *    {vector: [...], metadata: {}},
+   *    {vector: [...], metadata: {foo: 'bar'}},
+   *    // ...
+   * ]
+   * await dria.insertVectors(batch);
+   */
+  async insertVectors<M extends MetadataType = T>(items: BatchVectors<M>) {
+    items = BatchVectors.parse(items) as BatchVectors<M>;
+    const data = await this.post<string>("/insert_vector", {
+      data: items,
+    });
+    return data;
+  }
+}

--- a/src/clients/local.ts
+++ b/src/clients/local.ts
@@ -58,8 +58,10 @@ export class DriaLocal<T extends MetadataType = any> extends DriaCommon {
    * @example
    * const res = await dria.query<{about: string}>([0.1, 0.92, ..., 0.16]);
    * console.log(res[0].metadata.about);
+   *
+   * @deprecated local query is disabled right now
    */
-  async query<M extends MetadataType = T>(vector: number[], options: QueryOptions = {}) {
+  private async query<M extends MetadataType = T>(vector: number[], options: QueryOptions = {}) {
     options = QueryOptions.parse(options);
     const data = await this.post<{ id: number; metadata: M; score: number }[]>("/query", {
       vector,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,11 @@
 export default {
-  /** URL to make fetch / query / search requests */
-  DRIA_SEARCH_URL: "https://search.dria.co/hnsw",
-  /** URL to insert texts and vectors */
-  DRIA_INSERT_URL: "https://search.dria.co/hnswt",
-  /** URL to get model */
-  DRIA_API_URL: "https://api.dria.co",
+  // TODO: naming doesnt really make sense here...
+  DRIA: {
+    /** URL to make fetch / query / search requests */
+    SEARCH_URL: "https://search.dria.co/hnsw",
+    /** URL to insert texts and vectors */
+    INSERT_URL: "https://search.dria.co/hnswt",
+    /** URL to get model */
+    API_URL: "https://api.dria.co",
+  },
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { Dria } from "./dria";
+export { Dria, DriaLocal } from "./clients";
 export type { DriaParams } from "./types";

--- a/tests/local.test.ts
+++ b/tests/local.test.ts
@@ -1,0 +1,40 @@
+import { expect, describe, it } from "bun:test";
+import { randomVector } from "./utils";
+import { DriaLocal } from "../src";
+
+// you can setup a local Dria service via the Dria CLI (https://www.npmjs.com/package/dria-cli)
+// $ dria pull WbcY2a-KfDpk7fsgumUtLC2bu4NQcVzNlXWi13fPMlU
+// $ dria serve WbcY2a-KfDpk7fsgumUtLC2bu4NQcVzNlXWi13fPMlU
+
+// these tests are skipped unless specified with process.env.LOCAL_TEST
+const testLocal = process.env.LOCAL_TEST ?? false;
+(testLocal ? describe : describe.skip)("local client", () => {
+  type MetadataType = { id: string; page: string; text: string };
+  const dria = new DriaLocal<MetadataType>();
+
+  it("should be healthy", async () => {
+    const res = await dria.health();
+    expect(res).toBe(true);
+  });
+
+  it("should fetch with ids", async () => {
+    const ids = [0, 1, 2];
+    const res = await dria.fetch(ids);
+    res.forEach((r) => {
+      expect(r.id).toBeString();
+      expect(r.text).toBeString();
+    });
+  });
+
+  it("should query with a vector", async () => {
+    const vector = randomVector(768);
+    const res = await dria.query(vector);
+    expect(res.length).toBe(10); // default topK
+    res.forEach((r) => {
+      expect(r.id).toBeNumber();
+      expect(r.score).toBeNumber();
+      expect(r.metadata).toBeObject();
+      // TODO: test more metadata fields here
+    });
+  });
+});

--- a/tests/local.test.ts
+++ b/tests/local.test.ts
@@ -8,7 +8,7 @@ import { DriaLocal } from "../src";
 
 // these tests are skipped unless specified with process.env.LOCAL_TEST
 const testLocal = process.env.LOCAL_TEST ?? false;
-(testLocal ? describe : describe.skip)("local client", () => {
+describe.skipIf(!testLocal)("local client", () => {
   type MetadataType = { id: string; page: string; text: string };
   const dria = new DriaLocal<MetadataType>();
 
@@ -26,15 +26,14 @@ const testLocal = process.env.LOCAL_TEST ?? false;
     });
   });
 
-  it("should query with a vector", async () => {
-    const vector = randomVector(768);
-    const res = await dria.query(vector);
-    expect(res.length).toBe(10); // default topK
-    res.forEach((r) => {
-      expect(r.id).toBeNumber();
-      expect(r.score).toBeNumber();
-      expect(r.metadata).toBeObject();
-      // TODO: test more metadata fields here
-    });
-  });
+  // it.skip("should query with a vector", async () => {
+  //   const vector = randomVector(768);
+  //   const res = await dria.query(vector);
+  //   expect(res.length).toBe(10); // default topK
+  //   res.forEach((r) => {
+  //     expect(r.id).toBeNumber();
+  //     expect(r.score).toBeNumber();
+  //     expect(r.metadata).toBeObject();
+  //   });
+  // });
 });


### PR DESCRIPTION
Resolves #3 

There seems to be differences in the returned data format between the Dria API & local Dria @anilaltuner, we should address these for better compatibility between implementations & return type; so that a user can seamlessly switch between Dria API & local Dria for the exposed functions.